### PR TITLE
chore: only getting pending tasks in recent one week

### DIFF
--- a/stats/bridge_stats.go
+++ b/stats/bridge_stats.go
@@ -16,6 +16,7 @@ import (
 )
 
 const bridgeVersion = "v0.2.9"
+const timeRangeCheck = 60 * 60 * 24 * 7 // 1 Week
 
 type NodeInfo struct {
 	Organization  string `json:"organization,omitempty" mapstructure:"organization"`
@@ -268,15 +269,16 @@ func (s *Service) report(conn *connWrapper) error {
 		ProcessedBlock: s.processedBlock,
 	}
 
+	timestamp := time.Now().Unix() - timeRangeCheck // 1 week
 	// count pending/failed tasks from database
-	pending, err := s.store.CountTasks(s.chainId, "pending")
+	pending, err := s.store.CountTasks(s.chainId, "pending", timestamp)
 	if err != nil {
 		log.Error("error while getting pending tasks", "err", err)
 	} else {
 		info.PendingTasks = int(pending)
 	}
 
-	failed, err := s.store.CountTasks(s.chainId, "failed")
+	failed, err := s.store.CountTasks(s.chainId, "failed", timestamp)
 	if err != nil {
 		log.Error("error while getting failed tasks", "err", err)
 	} else {

--- a/stores/main.go
+++ b/stores/main.go
@@ -13,7 +13,7 @@ type TaskStore interface {
 	DeleteTasks([]string, uint64) error
 	Count() int64
 	ResetTo(ids []string, status string) error
-	CountTasks(chain, status string) (int64, error)
+	CountTasks(chain, status string, before int64) (int64, error)
 }
 
 type DepositStore interface {

--- a/stores/task.go
+++ b/stores/task.go
@@ -54,9 +54,9 @@ func (t *taskStore) GetTasks(chain, status string, limit, retrySeconds int, befo
 	return tasks, err
 }
 
-func (t *taskStore) CountTasks(chain, status string) (int64, error) {
+func (t *taskStore) CountTasks(chain, status string, before int64) (int64, error) {
 	var count int64
-	err := t.Model(&models.Task{}).Where("chain_id = ? AND status = ?", chain, status).Count(&count).Error
+	err := t.Model(&models.Task{}).Where("chain_id = ? AND status = ? AND created_at >= ?", chain, status, before).Count(&count).Error
 	return count, err
 }
 


### PR DESCRIPTION
Only show failed/pending tasks in recent timeRangeCheck for avoiding unused data.