### PR TITLE
fix: remove fallback to current block height

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/axieinfinity/bridge-v2
 
 replace (
-	github.com/axieinfinity/bridge-core => github.com/ronin-chain/bridge-core v0.1.3-0.20240625082548-579437b59387
+	github.com/axieinfinity/bridge-core => github.com/ronin-chain/bridge-core v0.1.3-0.20240802083006-6bc6ef92476e
 	github.com/ethereum/go-ethereum => github.com/axieinfinity/ronin v1.10.4-0.20240117085004-bf2f0d1787d0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/ronin-chain/bridge-core v0.1.3-0.20240625082548-579437b59387 h1:5oKcWsJOpY6NbHxMr0RwWb8OVKvPwpvKsok2vqmYClI=
-github.com/ronin-chain/bridge-core v0.1.3-0.20240625082548-579437b59387/go.mod h1:X6QX0BsMR432Ez8ShNavbC0Sp7rtVthfGWdLtg174ag=
+github.com/ronin-chain/bridge-core v0.1.3-0.20240802083006-6bc6ef92476e h1:bevKSsUgIyW1nTI7HygtYLBjZz1zHo7jX0esZaC9joQ=
+github.com/ronin-chain/bridge-core v0.1.3-0.20240802083006-6bc6ef92476e/go.mod h1:X6QX0BsMR432Ez8ShNavbC0Sp7rtVthfGWdLtg174ag=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=


### PR DESCRIPTION
When starting a new node, if we cannot get the information about fromHeight block possibly due to flaky RPC, we fallbacks to get the latest block. This can make the operator assume that all blocks from fromHeight to latest block have been processed. This commit removes the fallback and always retries to get the fromHeight block.